### PR TITLE
Week 6: add skill-analysis lesson 03 + thread it through the materials

### DIFF
--- a/week_06/02_sampling_compression.ipynb
+++ b/week_06/02_sampling_compression.ipynb
@@ -111,6 +111,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4d8383ab",
+   "source": "### Bonus: keyword frequency hints (cheap skill evidence)\n\nSampling shows the model *what postings look like*; it does not tell it *which\nskills recur*. A cheap, deterministic complement is a **keyword frequency hint**:\ncount how many postings mention each known skill. This is exactly the kind of\ncompact evidence the capstone's LLM step reasons over.\n\nThe full flow — evidence → prompt → validate → report — is covered in\n[03_skill_analysis.md](./03_skill_analysis.md).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "8609ecfc",
+   "source": "import re\n\nSKILL_KEYWORDS = [\"python\", \"sql\", \"excel\", \"tableau\", \"power bi\", \"aws\",\n                  \"azure\", \"spark\", \"docker\", \"machine learning\", \"communication\"]\n\n\ndef skill_frequency_hints(df, text_col=\"job_description\", keywords=SKILL_KEYWORDS):\n    # Count how many postings mention each known skill (whole-word match).\n    texts = df[text_col].dropna().astype(str).str.lower()\n    counts = {kw: int(texts.str.contains(r\"\\b\" + re.escape(kw) + r\"\\b\", regex=True).sum())\n              for kw in keywords}\n    return {k: v for k, v in sorted(counts.items(), key=lambda kv: kv[1], reverse=True) if v}\n\n\nif pd is None:\n    print(\"pandas not available; skipping keyword hints\")\nelif \"jobs\" not in globals():\n    print(\"run the job-postings compression cell above first\")\nelse:\n    # `jobs` was loaded in the job-postings compression cell above.\n    print(\"skill keyword hints:\", skill_frequency_hints(jobs))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
    "id": "8a60b5c0",
    "source": "### Estimating the token budget\n\nBefore sending anything to an LLM, estimate how many tokens the compressed object will cost. A rough rule is **~4 characters per token**. Keep the compressed data well under **~2,000 tokens** so the system prompt, task instructions, and the model's output budget all still fit inside the context window.\n\nThe next cell defines `estimate_tokens()` and checks both the small table payload and the real job-postings payload against that budget.",
    "metadata": {}

--- a/week_06/03_skill_analysis.ipynb
+++ b/week_06/03_skill_analysis.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "952be0fd",
+   "metadata": {},
+   "source": "# Week 6 — Part 03: How the job-skill analysis works\n\n**Estimated time:** 60–90 minutes\n\n## What success looks like (end of Part 03)\n\n- You can name which stage actually identifies skills (the LLM stage) and which\n  stages only prepare evidence.\n- You can produce cheap, deterministic **keyword frequency hints** from job\n  descriptions.\n- You can assemble the evidence, build a structured prompt, validate the model\n  output, and map it into the stable report schema.\n\n## Learning Objectives\n\n- Gather skill evidence from free text without sending full descriptions\n- Build a structured prompt that asks for the theme skill fields\n- Validate the LLM output and map it into `report.json`'s schema\n\n**Lab tutorial**: [03_skill_analysis.md](./03_skill_analysis.md) — detailed walkthrough.\n\n> This notebook runs **offline**: the keyword-frequency step is real, and the LLM\n> step is mocked. The capstone replaces the mock with a real provider call (see\n> `capstone_template/src/llm_interpretation.py`)."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7b0d361",
+   "metadata": {},
+   "source": "### The big idea\n\nThe \"analysis\" — extracting skills, clustering roles, ranking what to learn —\nhappens in the **LLM stage**. Everything before it exists to hand the model the\nright **evidence**, cheaply and reproducibly:\n\n```text\nload -> profile -> compress (skill evidence) -> LLM -> validate -> report\n```\n\nWe walk those steps on the real 60-row sample at `data/sample_job_postings.csv`."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f7a7324",
+   "metadata": {},
+   "source": "## Step 1 — Gather skill evidence (keyword frequency hints)\n\nMost skill signal is buried in `job_description` free text. A cheap first pass:\nscan descriptions for known skills and count how many postings mention each.\n\nThis is fast, free, and explainable — but it only finds **known terms** and\ncannot cluster roles or rank a learning path. We use it as *evidence for the\nmodel*, not as the final answer."
+  },
+  {
+   "cell_type": "code",
+   "id": "c63bc272",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import json\nimport re\nfrom pathlib import Path\n\nimport pandas as pd\n\nCSV_PATH = Path(\"data/sample_job_postings.csv\")\nOUTPUT_DIR = Path(\"output\")\nOUTPUT_DIR.mkdir(exist_ok=True)\n\njobs = pd.read_csv(CSV_PATH)\n\nSKILL_KEYWORDS = [\n    \"python\", \"sql\", \"excel\", \"tableau\", \"power bi\", \"aws\", \"azure\",\n    \"spark\", \"airflow\", \"docker\", \"kubernetes\", \"pandas\", \"scikit-learn\",\n    \"tensorflow\", \"pytorch\", \"machine learning\", \"nlp\", \"etl\",\n    \"data visualization\", \"statistics\", \"git\", \"communication\", \"dashboard\",\n]\n\n\ndef skill_frequency_hints(df, text_col=\"job_description\", keywords=SKILL_KEYWORDS, top_k=15):\n    \"\"\"Count how many postings mention each known skill (cheap, deterministic).\"\"\"\n    texts = df[text_col].dropna().astype(str).str.lower()\n    counts = {}\n    for kw in keywords:\n        pattern = r\"\\b\" + re.escape(kw) + r\"\\b\"   # whole-word match\n        n = int(texts.str.contains(pattern, regex=True).sum())\n        if n:\n            counts[kw] = n\n    return dict(sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:top_k])\n\n\nhints = skill_frequency_hints(jobs)\nprint(f\"Scanned {len(jobs)} postings. Top skill mentions:\")\nfor skill, n in hints.items():\n    print(f\"  {skill:20} {n:>3} postings\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8152046",
+   "metadata": {},
+   "source": "## Step 2 — Compress the evidence under the token budget\n\nYou cannot send 60 full descriptions to the model. Combine the cheap evidence\ninto a small, bounded object, then estimate its token cost (~4 chars/token) and\nkeep it well under ~2,000 tokens."
+  },
+  {
+   "cell_type": "code",
+   "id": "0897ce8a",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "def estimate_tokens(obj, chars_per_token=4.0):\n    return int(len(json.dumps(obj)) / chars_per_token)\n\n\ndef existing_skill_strings(df, n=10):\n    if \"job_skills\" not in df.columns:\n        return []\n    return df[\"job_skills\"].dropna().astype(str).head(n).tolist()\n\n\nevidence = {\n    \"n_postings\": int(len(jobs)),\n    \"top_job_titles\": {\n        str(k): int(v) for k, v in jobs[\"job_title\"].value_counts().head(8).to_dict().items()\n    },\n    \"skill_keyword_hints\": hints,\n    \"existing_skill_strings\": existing_skill_strings(jobs),   # often empty in this dataset\n    \"sample_descriptions\": (\n        jobs[\"job_description\"].dropna().astype(str).str.slice(0, 280).head(3).tolist()\n    ),\n    \"note\": \"Compressed evidence only. Full descriptions are never sent in bulk.\",\n}\n\nprint(f\"Evidence is ~{estimate_tokens(evidence)} tokens (budget: < 2000)\")\n(OUTPUT_DIR / \"skill_evidence.json\").write_text(json.dumps(evidence, indent=2, sort_keys=True), encoding=\"utf-8\")\nprint(\"wrote:\", OUTPUT_DIR / \"skill_evidence.json\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4823d0a8",
+   "metadata": {},
+   "source": "## Step 3 — Build the structured prompt\n\nThe prompt asks for **JSON only**, with the theme skill fields, and tells the\nmodel to use *only the supplied evidence* and to flag uncertainty in\n`risk_notes`. That constraint is what keeps a skill analyzer from drifting into\ngeneric career advice."
+  },
+  {
+   "cell_type": "code",
+   "id": "bc67f142",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "THEME_FIELDS = [\n    \"common_skills\", \"common_tools\", \"role_clusters\",\n    \"learning_priorities\", \"beginner_learning_path\", \"portfolio_project_ideas\",\n]\n\n\ndef build_prompt(evidence: dict) -> str:\n    return f\"\"\"You are a careful job-market analyst.\n\nUse ONLY the evidence below. Do not invent skills that are not supported by it.\n\nReturn ONLY valid JSON with these keys:\n- summary: one short paragraph\n- common_skills: list of frequently required technical skills\n- common_tools: list of tools, platforms, or frameworks\n- role_clusters: list of role families you see in the titles\n- learning_priorities: ordered list of what a beginner should learn first\n- beginner_learning_path: ordered list describing a sensible learning sequence\n- portfolio_project_ideas: list of small projects that practice these skills\n- risk_notes: list of caveats (small sample, truncated text, missing fields)\n\nEvidence:\n{json.dumps(evidence, indent=2, sort_keys=True)}\n\"\"\"\n\n\nprompt = build_prompt(evidence)\n(OUTPUT_DIR / \"llm_prompt.txt\").write_text(prompt, encoding=\"utf-8\")\nprint(prompt[:600], \"\\n...\\n\")\nprint(\"wrote:\", OUTPUT_DIR / \"llm_prompt.txt\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2adc0d26",
+   "metadata": {},
+   "source": "## Step 4 — Call the LLM (mock here, real in the capstone)\n\nIn the capstone, `call_llm()` makes a real provider call with timeout/retry.\nHere we use a **debug-only mock** so the notebook runs offline. Either way, the\nnext thing you do is the same: **validate** the raw text before trusting it."
+  },
+  {
+   "cell_type": "code",
+   "id": "8c421b4d",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "def call_llm_mock(prompt: str) -> str:\n    \"\"\"DEBUG-ONLY stub. The capstone replaces this with a real provider call.\"\"\"\n    return json.dumps({\n        \"summary\": \"Analyst and engineering roles dominate; SQL, Python and dashboarding recur.\",\n        \"common_skills\": [\"SQL\", \"Python\", \"data visualization\", \"communication\", \"statistics\"],\n        \"common_tools\": [\"Tableau\", \"Power BI\", \"Excel\", \"AWS\", \"Git\"],\n        \"role_clusters\": [\"Data Analyst\", \"Data/ML Engineer\", \"BI Developer\"],\n        \"learning_priorities\": [\"SQL\", \"Python\", \"dashboarding\", \"basic statistics\"],\n        \"beginner_learning_path\": [\n            \"Learn SQL queries\", \"Learn Python + pandas\",\n            \"Build a dashboard in Tableau/Power BI\", \"Document and present findings\",\n        ],\n        \"portfolio_project_ideas\": [\n            \"A SQL + dashboard report over a public dataset\",\n            \"An ETL script that cleans and profiles a CSV\",\n        ],\n        \"risk_notes\": [\"Small sample (60 rows)\", \"Descriptions truncated\", \"job_skills mostly empty\"],\n    })\n\n\nREQUIRED_LLM_KEYS = [\"summary\", *THEME_FIELDS, \"risk_notes\"]\n\n\ndef validate_llm_output(raw_response: str) -> dict:\n    \"\"\"Parse JSON, check required keys, coerce missing lists to [].\"\"\"\n    data = json.loads(raw_response)              # in real code: wrap in try/except + one repair attempt\n    missing = [k for k in REQUIRED_LLM_KEYS if k not in data]\n    if missing:\n        raise ValueError(f\"LLM output missing keys: {missing}\")\n    for k in REQUIRED_LLM_KEYS:\n        if k != \"summary\" and not isinstance(data[k], list):\n            data[k] = []\n    return data\n\n\nraw_response = call_llm_mock(prompt)\n(OUTPUT_DIR / \"llm_raw_response.txt\").write_text(raw_response, encoding=\"utf-8\")\nllm_output = validate_llm_output(raw_response)\nprint(\"validated. common_skills:\", llm_output[\"common_skills\"])\nprint(\"role_clusters:\", llm_output[\"role_clusters\"])"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc22cdc4",
+   "metadata": {},
+   "source": "## Step 5 — Map into the stable report schema\n\nThe skill fields live **inside** `llm_interpretation`; the top-level report keys\nstay fixed so every run looks the same to a reviewer. This mirrors\n`capstone_template/src/report_builder.py`."
+  },
+  {
+   "cell_type": "code",
+   "id": "b36b5835",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "def build_json_report(jobs, evidence, llm_output) -> dict:\n    return {\n        \"metadata\": {\"source\": \"week6 lesson 03 (mock LLM)\"},\n        \"dataset_summary\": {\"rows\": int(len(jobs)), \"columns\": int(jobs.shape[1])},\n        \"data_quality\": {\"job_skills_non_empty\": int(jobs[\"job_skills\"].notna().sum())},\n        \"compression_summary\": {\"evidence_tokens_est\": estimate_tokens(evidence)},\n        \"llm_interpretation\": {\n            \"summary\": llm_output[\"summary\"],\n            \"common_skills\": llm_output[\"common_skills\"],\n            \"common_tools\": llm_output[\"common_tools\"],\n            \"role_clusters\": llm_output[\"role_clusters\"],\n            \"learning_priorities\": llm_output[\"learning_priorities\"],\n            \"beginner_learning_path\": llm_output[\"beginner_learning_path\"],\n            \"portfolio_project_ideas\": llm_output[\"portfolio_project_ideas\"],\n        },\n        \"recommendations\": llm_output[\"learning_priorities\"],\n        \"risk_notes\": llm_output[\"risk_notes\"],\n        \"errors_or_warnings\": [],\n    }\n\n\nreport = build_json_report(jobs, evidence, llm_output)\n(OUTPUT_DIR / \"report.json\").write_text(json.dumps(report, indent=2, sort_keys=True), encoding=\"utf-8\")\n\nprint(\"top-level report keys:\", list(report.keys()))\nprint(\"\\nllm_interpretation preview:\")\nprint(json.dumps(report[\"llm_interpretation\"], indent=2)[:600], \"...\")\nprint(\"\\nwrote:\", OUTPUT_DIR / \"report.json\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad0948c4",
+   "metadata": {},
+   "source": "## Keyword hints vs LLM — and why we use both\n\n| | Keyword frequency | LLM interpretation |\n|---|---|---|\n| Cost | Free | API cost + latency |\n| Explainable | Yes | Partially |\n| Finds synonyms / new skills | No | Yes |\n| Clusters, ranks, sequences | No | Yes |\n| Can hallucinate | No | Yes |\n\nKeyword hints are cheap, grounded **evidence**; the LLM turns that evidence into\nclustered, ranked, human-readable guidance — while being told to stay within the\nevidence.\n\n### Self-check\n\n- Which stage actually identified the skills? Which only prepared evidence?\n- If you removed the keyword hints, what could the model no longer ground on?\n- Are the skill fields nested in `llm_interpretation` with top-level keys fixed?\n- What does your project do when `job_skills` is empty?\n\n### Next step\n\nSwap `call_llm_mock` for a real provider call (see\n`capstone_template/src/llm_interpretation.py`) and keep everything else the same."
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/week_06/03_skill_analysis.md
+++ b/week_06/03_skill_analysis.md
@@ -1,0 +1,195 @@
+# Week 6 — Part 03: How the job-skill analysis works (evidence → LLM → report)
+
+## Overview
+
+The Week 6 capstone is a **Job Posting Skill Analyzer**, but the actual
+"analysis" — identifying skills, clustering roles, ranking learning priorities —
+does **not** happen with keyword counting. It happens in the **LLM stage**. Every
+earlier stage exists to gather and compress *skill-relevant evidence* so the
+model can reason over it cheaply and reproducibly.
+
+Pipeline, viewed through a skill lens:
+
+```text
+job postings CSV
+  -> profile             (which roles dominate? how much is missing?)
+  -> compress            (cheap skill evidence: title counts, skill strings,
+                          keyword frequency hints, sampled descriptions)
+  -> LLM interpretation  (extract skills/tools, cluster roles,
+                          rank learning priorities, suggest a path)
+  -> report.json + report.md
+```
+
+**Lab notebook**: [03_skill_analysis.ipynb](./03_skill_analysis.ipynb) — runs the whole flow on the real 60-row sample.
+
+---
+
+## Where the skill analysis happens
+
+| Stage | What it contributes to skill analysis |
+|-------|----------------------------------------|
+| **Load** | Brings in `job_description` (most skill signal) and `job_skills` (explicit skills, often empty). |
+| **Profile** | Context, not skills: `top_job_titles`, missing rates, row counts. Tells the model what kind of roles dominate. |
+| **Compress** | The "evidence-gathering" step: title/location counts, sampled `job_skills` strings, **keyword frequency hints**, and short representative descriptions. |
+| **LLM** | The real analysis: extract and de-duplicate skills/tools, cluster roles, rank learning priorities, build a beginner path, propose projects. |
+| **Report** | Maps the model's structured skill output into a stable `report.json` / `report.md`. |
+
+The "intelligence" (extract → cluster → rank → sequence) lives in the LLM stage.
+The pipeline's job is to make sure the model sees the **right evidence**, within
+the token budget, every run.
+
+---
+
+## Step 1 — Gather skill evidence (cheap and deterministic)
+
+Most skill signal is buried in `job_description` free text (e.g. "build
+dashboards, write SQL queries"). A cheap first pass is a **keyword frequency
+hint**: scan descriptions for a list of known skills and count how many postings
+mention each one.
+
+```python
+import re
+
+SKILL_KEYWORDS = [
+    "python", "sql", "excel", "tableau", "power bi", "aws", "azure",
+    "spark", "airflow", "docker", "kubernetes", "pandas", "scikit-learn",
+    "tensorflow", "pytorch", "machine learning", "nlp", "etl",
+    "data visualization", "statistics", "git", "communication", "dashboard",
+]
+
+
+def skill_frequency_hints(df, text_col="job_description", keywords=SKILL_KEYWORDS, top_k=15):
+    texts = df[text_col].dropna().astype(str).str.lower()
+    counts = {}
+    for kw in keywords:
+        pattern = r"\b" + re.escape(kw) + r"\b"
+        n = int(texts.str.contains(pattern, regex=True).sum())
+        if n:
+            counts[kw] = n
+    return dict(sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:top_k])
+```
+
+This is fast, free, and explainable. But it can only count **known terms**: it
+cannot recognize synonyms ("writing SQL" vs "SQL queries"), cluster roles, or
+build a learning path. Those need the LLM. So we use the hints as *evidence to
+hand the model*, not as the final answer.
+
+---
+
+## Step 2 — Compress the evidence under the token budget
+
+You cannot send 60 full descriptions to the model. Combine the cheap evidence
+into a small, bounded object:
+
+- `top_job_titles` (role distribution)
+- `skill_keyword_hints` (from Step 1)
+- a few **truncated** representative descriptions
+- existing `job_skills` strings, if present
+
+Then estimate tokens (~4 chars/token) and keep it well under ~2,000 tokens.
+See [02_sampling_compression.md](./02_sampling_compression.md) for the
+compression mechanics.
+
+---
+
+## Step 3 — Ask the LLM for structured skill analysis
+
+The prompt instructs the model to return **JSON only**, grounded in the supplied
+evidence. For this theme (see
+[capstone_template/theme_examples/job_posting_schema.md](./capstone_template/theme_examples/job_posting_schema.md))
+ask for:
+
+| Field | Meaning | What the model is doing |
+|-------|---------|--------------------------|
+| `common_skills` | High-frequency technical skills | Generalize repeated skills across postings |
+| `common_tools` | Tools / platforms / frameworks | Extract and de-duplicate tool names |
+| `role_clusters` | Role families | Group similar titles + descriptions |
+| `learning_priorities` | What a beginner should learn first | Rank by frequency + complementarity |
+| `beginner_learning_path` | Ordered path | Sequence skills into a sensible order |
+| `portfolio_project_ideas` | Practice projects | Map skills to buildable projects |
+
+**Key rule:** tell the model to use *only the given evidence* and to report
+uncertainty (small sample, truncated text) in `risk_notes`. This is what keeps a
+"skill analyzer" from drifting into generic career advice.
+
+---
+
+## Step 4 — Validate the model output
+
+Never trust raw model text. Parse and validate before using it:
+
+- parse JSON from the raw response,
+- check the required keys are present,
+- coerce missing optional lists to `[]`,
+- try **one** repair attempt, then fail with a clear error.
+
+This is the same contract as
+[capstone_template/src/llm_interpretation.py](./capstone_template/src/llm_interpretation.py)
+(`validate_llm_output`).
+
+---
+
+## Step 5 — Map into the stable report schema
+
+The skill fields live **inside** `llm_interpretation`; the top-level report keys
+stay fixed so every run looks the same to a reviewer:
+
+```text
+report.json (top level, always present):
+  metadata, dataset_summary, data_quality, compression_summary,
+  llm_interpretation, recommendations, risk_notes, errors_or_warnings
+
+llm_interpretation:
+  common_skills, common_tools, role_clusters,
+  learning_priorities, beginner_learning_path, portfolio_project_ideas
+```
+
+---
+
+## Keyword frequency vs LLM: use both
+
+| | Keyword frequency | LLM interpretation |
+|---|---|---|
+| Cost | Free | API cost + latency |
+| Explainable | Yes (you can see the count) | Partially |
+| Finds synonyms / new skills | No | Yes |
+| Clusters roles, ranks, sequences | No | Yes |
+| Can hallucinate | No | Yes |
+
+The pipeline combines them: keyword hints are cheap, grounded evidence; the LLM
+turns that evidence into clustered, ranked, human-readable guidance — and is
+asked to stay within the evidence.
+
+---
+
+## Common failure points
+
+- Compression drops tool names or rare roles → skills are under-counted. Keep
+  edge-case samples.
+- Descriptions truncated too aggressively → missing signal. Tune the truncation
+  length.
+- The model gives generic career advice instead of using the evidence → enforce
+  "use only the supplied evidence" in the prompt.
+- `job_skills` is empty but treated as populated → fall back to inferring skills
+  from `job_description`.
+
+---
+
+## Self-check
+
+- Which stage actually identifies the skills — and which stages only prepare
+  evidence?
+- If you removed the keyword hints, what could the LLM no longer ground its
+  answer on?
+- Are your skill fields nested inside `llm_interpretation` with the top-level
+  report keys unchanged?
+- Does your prompt force the model to stay within the supplied evidence?
+- What does your project do when `job_skills` is empty?
+
+---
+
+## References
+
+- Theme schema: [capstone_template/theme_examples/job_posting_schema.md](./capstone_template/theme_examples/job_posting_schema.md)
+- Compression mechanics: [02_sampling_compression.md](./02_sampling_compression.md)
+- LLM client + validation: [capstone_template/src/llm_interpretation.py](./capstone_template/src/llm_interpretation.py)

--- a/week_06/README.md
+++ b/week_06/README.md
@@ -8,6 +8,24 @@ The required MVP is intentionally fixed:
 CSV input -> data overview -> sampled/compressed summary -> real LLM interpretation -> report.json + report.md
 ```
 
+## How the skill analysis works
+
+The "analysis" — identifying skills, clustering roles, ranking what to learn —
+happens in the **LLM stage**. Every earlier stage exists to gather and compress
+*skill-relevant evidence* so the model can reason over it cheaply and the same
+way every run:
+
+| Stage | Role in the skill analysis |
+|-------|-----------------------------|
+| **Load** | Read the CSV. `job_description` holds most skill signal; `job_skills` is explicit but often empty. |
+| **Profile** | Context: top job titles, missing values, counts. |
+| **Compress** | Cheap, deterministic **skill evidence**: title/location counts, sampled `job_skills`, keyword frequency hints, and short truncated descriptions. Never the full CSV. |
+| **LLM** | The real analysis: extract skills/tools, cluster roles, rank learning priorities, build a beginner path, propose projects — grounded in the evidence. |
+| **Report** | Map the model's skill fields into `report.json` under `llm_interpretation`, with stable top-level keys. |
+
+Walkthrough: [03_skill_analysis.md](03_skill_analysis.md) (lab notebook runs the
+whole flow offline on the real sample).
+
 ## Main Project
 
 Build a **Job Posting Skill Analyzer**.
@@ -58,6 +76,7 @@ Capstone-required:
 - [capstone_template/](capstone_template/)
 - [01_pipeline_design.md](01_pipeline_design.md)
 - [02_sampling_compression.md](02_sampling_compression.md)
+- [03_skill_analysis.md](03_skill_analysis.md)
 
 Theme examples:
 

--- a/week_06/capstone_template/src/compression.py
+++ b/week_06/capstone_template/src/compression.py
@@ -23,4 +23,14 @@ def compress_profile(profile: dict, df: Any) -> dict:
     # TODO: sample a small number of rows with a fixed seed.
     # TODO: include top categories and numeric ranges from the profile.
     # TODO: estimate or describe why the compressed object is small enough.
+    #
+    # Job-skill theme: the LLM identifies the skills, but it can only reason over
+    # the evidence you put here. Besides sampled rows, add cheap, deterministic
+    # SKILL EVIDENCE so the model has something to ground its answer on:
+    #   - top_job_titles (role distribution)
+    #   - existing job_skills strings, if the column is populated
+    #   - keyword frequency hints: count how many postings mention each known
+    #     skill (e.g. python, sql, tableau) — cheap, explainable, and compact
+    #   - a few truncated representative job_description samples
+    # See 03_skill_analysis.md for the full evidence -> prompt -> report flow.
     raise NotImplementedError("TODO: implement compress_profile()")

--- a/week_06/capstone_template/src/llm_interpretation.py
+++ b/week_06/capstone_template/src/llm_interpretation.py
@@ -17,6 +17,19 @@ REQUIRED_LLM_KEYS = [
 def build_prompt(compressed: dict) -> str:
     """Build a structured prompt from the compressed data summary."""
     # TODO: adapt this prompt to your chosen topic.
+    #
+    # This is where the skill ANALYSIS happens: the model reads the compressed
+    # evidence and produces structured skill insights. Two rules keep it honest:
+    #   1. Tell it to use ONLY the supplied evidence (no generic career advice),
+    #      and to report uncertainty (small sample, truncated text) in risk_notes.
+    #   2. Ask for JSON only, so validate_llm_output() can parse it reliably.
+    #
+    # For the job-posting theme, request these fields and map them inside
+    # report.json's `llm_interpretation` (keep the top-level report keys stable):
+    #   common_skills, common_tools, role_clusters,
+    #   learning_priorities, beginner_learning_path, portfolio_project_ideas
+    # The default prompt below asks for generic fields; swap in the ones above.
+    # See 03_skill_analysis.md for a worked example.
     return f"""You are a careful data analysis assistant.
 
 Analyze the compressed dataset summary below.


### PR DESCRIPTION
## Summary

Adds a dedicated Week 6 lesson on **how the job-skill analysis actually works**, and threads that explanation through the existing materials. Builds on #4.

### New lesson
- **`03_skill_analysis.md`** — explains the end-to-end flow: the LLM stage does the analysis; earlier stages gather and compress *skill evidence*. Covers keyword-frequency hints, evidence compression, the structured prompt (theme fields), output validation, and mapping into the stable `report.json` schema. Includes a keyword-vs-LLM trade-off table and common failure points.
- **`03_skill_analysis.ipynb`** — runs the whole flow **offline** on the real 60-row sample: real keyword-frequency extraction → compressed evidence (~833 tokens) → structured prompt → **mocked** LLM + validation → mapped into the 8-key report schema. The mock is clearly labeled; the capstone swaps in a real provider call.

### Threaded through existing materials
- **Notebook 02** — added an annotated keyword-frequency skill-evidence cell that points to lesson 03.
- **capstone_template** — added explanatory comments (behavior unchanged):
  - `src/compression.py`: include keyword frequency hints as cheap skill evidence.
  - `src/llm_interpretation.py` `build_prompt`: the theme skill fields + the "use only the supplied evidence" rule.
- **README** — new "How the skill analysis works" stage table, and lesson 03 listed under Main Materials.

## Verification
- All three notebooks execute end-to-end with no errors.
- Edited template files pass `py_compile`.
- Links referenced by lesson 03 resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
